### PR TITLE
fix: Change name in LICENSE to aaesalamanca

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Alejandro Estornell
+Copyright (c) 2025 aaesalamanca
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
It changes the name associated with the LICENSE to match the convention between repositories.